### PR TITLE
Fix release notes tabs and keep release + ESR entries

### DIFF
--- a/assets/less/components/tabs.less
+++ b/assets/less/components/tabs.less
@@ -9,6 +9,7 @@
 }
 
 #release:checked ~ section.tab.release,
+#esr:checked ~ section.tab.esr,
 #beta:checked ~ section.tab.beta,
 #daily:checked ~ section.tab.daily {
   display: flex;
@@ -34,6 +35,7 @@
 }
 
 #release:checked ~ aside nav .tabs-nav .release label,
+#esr:checked ~ aside nav .tabs-nav .esr label,
 #beta:checked ~ aside nav .tabs-nav .beta label,
 #daily:checked ~ aside nav .tabs-nav .daily label {
   &:extend(.bg-blue, .text-white);

--- a/build-site.py
+++ b/build-site.py
@@ -91,6 +91,7 @@ else:
                'full_builds_beta': helper.thunderbird_desktop.get_filtered_full_builds('beta', beta_version),
                'channel_label': 'Thunderbird',
                'releases': helper.thunderbird_desktop.list_releases(),
+               'beta_versions': helper.thunderbird_desktop.list_beta_versions(),
                'calendars': caldata['calendars'],
                'letters': caldata['letters'],
                'CALDATA_URL': settings.CALDATA_URL,

--- a/sites/www.thunderbird.net/thunderbird/releases/index.html
+++ b/sites/www.thunderbird.net/thunderbird/releases/index.html
@@ -12,28 +12,43 @@
 {% endblock %}
 {% block content %}
 <section>
-  <div class="container no-gap">
-    <div class="section-text two-columns">
-      <div>
-      <p>{{ _('Thunderbird release notes are specific to each version of the application. Select your version from the list below to see the release notes for it.') }}</p>
+  <div class="container no-gap tabs">
+    <input type="radio" name="release-tabs" id="release" checked>
+    <input type="radio" name="release-tabs" id="esr">
+    <input type="radio" name="release-tabs" id="beta">
+
+    <aside>
+      <nav>
+        <ul class="tabs-nav">
+          <li class="release"><label for="release">{{ _('Release') }}</label></li>
+          <li class="esr"><label for="esr">{{ _('ESR') }}</label></li>
+          <li class="beta"><label for="beta">{{ _('Beta') }}</label></li>
+        </ul>
+      </nav>
+    </aside>
+
+    <section class="tab release">
+      <div class="section-text two-columns">
+        <div>
+        <p>{{ _('Thunderbird release notes are specific to each version of the application. Select your version from the list below to see the release notes for it.') }}</p>
+        </div>
+        <div class="atom-feed">
+          <a href="{{ url('thunderbird.releases.atom') }}" title="{{ _('Thunderbird Release Notes Atom Feed') }}">
+            {{ svg('rss') }}
+          </a>
+        </div>
       </div>
-      <div class="atom-feed">
-        <a href="{{ url('thunderbird.releases.atom') }}" title="{{ _('Thunderbird Release Notes Atom Feed') }}">
-          {{ svg('rss') }}
-        </a>
-      </div>
-    </div>
-    <div class="section-text release-list">
-        {% for int_version, versions in releases -%}
+      <div class="section-text release-list">
+        {% for int_version, versions in releases if versions.channel == 'release' -%}
           <div class="release-container">
             <h2 class="release-major txt-gradient">
-              {{ get_link(int_version, versions.major) }}
+              {{ get_link(int_version|float, versions.major) }}
             </h2>
             {% if versions.minor -%}
             <div class="release-minors">
               <ul aria-label="{{ _('Stability releases for version %(version)s'|format(version=versions.major)) }}">
               {% for version in versions.minor -%}
-                <li>{{ get_link(int_version, version, true) }}</li>
+                <li>{{ get_link(int_version|float, version, true) }}</li>
               {% endfor -%}
               </ul>
             </div>
@@ -59,6 +74,43 @@
           </div>
         </div>
       </div>
+    </section>
+
+    <section class="tab esr">
+      <div class="section-text release-list">
+        {% for int_version, versions in releases if versions.channel == 'esr' -%}
+          <div class="release-container">
+            <h2 class="release-major txt-gradient">
+              {{ get_link(int_version|float, versions.major) }}
+            </h2>
+            {% if versions.minor -%}
+            <div class="release-minors">
+              <ul aria-label="{{ _('Stability releases for version %(version)s'|format(version=versions.major)) }}">
+              {% for version in versions.minor -%}
+                <li>{{ get_link(int_version|float, version, true) }}</li>
+              {% endfor -%}
+              </ul>
+            </div>
+            {% endif -%}
+          </div>
+        {% endfor -%}
+      </div>
+    </section>
+
+    <section class="tab beta">
+      <div class="section-text release-list">
+        <div class="release-container">
+          <div class="release-minors">
+            <ul aria-label="{{ _('Beta releases') }}">
+            {% for version in beta_versions -%}
+              {% set int_version = version.split('.')[0]|float %}
+              <li>{{ get_link(int_version, version, true) }}</li>
+            {% endfor -%}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
 
   </div>
 </section>
@@ -97,3 +149,4 @@
     <a href="../../../en-US/thunderbird/{{ version }}/releasenotes/" class="inline-link text-blue-dark font-bold no-underline{{ class }}">{{ version }}</a>
   {%- endif -%}
 {% endmacro %}
+

--- a/tests/test_product_details.py
+++ b/tests/test_product_details.py
@@ -18,7 +18,13 @@ class TestListReleases:
         with open(os.path.join(fixtures_path, 'thunderbird.json'), 'r') as fh:
             thunderbird_desktop.releases = json.loads(fh.read())
 
-        list_releases_result = dict(thunderbird_desktop.list_releases())
+        list_releases_result = {
+            k: {
+                'major': v['major'],
+                'minor': v['minor']
+            }
+            for k, v in thunderbird_desktop.list_releases()
+        }
 
         # 128.0 wasn't in thunderbird_history_major/stability_releases.json, so it's not included here
         assert 128.0 not in list_releases_old_result
@@ -43,7 +49,22 @@ class TestListReleases:
         with open(os.path.join(fixtures_path, 'thunderbird.json'), 'r') as fh:
             thunderbird_desktop.releases = json.loads(fh.read())
 
-        list_releases_result = dict(thunderbird_desktop.list_releases())
+        list_releases_result = {
+            k: v for k, v in thunderbird_desktop.list_releases()
+        }
 
         assert 128.0 in list_releases_result
         assert '128.0.1esr' in list_releases_result[128.0]['minor']
+
+    def test_release_and_esr_versions_coexist(self):
+        """Major and ESR releases with the same base version should both exist."""
+
+        with open('libs/product-details/public/1.0/thunderbird.json', 'r') as fh:
+            thunderbird_desktop.releases = json.loads(fh.read())
+
+        releases = thunderbird_desktop.list_releases()
+        release_majors = [v['major'] for _, v in releases if v['channel'] == 'release']
+        esr_majors = [v['major'] for _, v in releases if v['channel'] == 'esr']
+
+        assert '140.0' in release_majors
+        assert '140.0esr' in esr_majors


### PR DESCRIPTION
## Summary
- keep both release and ESR entries when they share a base version
- group releases by channel using their category information
- split release notes template into Release, ESR, and Beta tabs

## Testing
- `pip install -r requirements-test.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686da74d86d483208aad5c6980a723e8